### PR TITLE
Fix increase in black levels when windows HDR mode is enabled

### DIFF
--- a/mouse2joystick_Custom_CEMU.ahk
+++ b/mouse2joystick_Custom_CEMU.ahk
@@ -203,7 +203,7 @@ snapToFullTilt:=0.005							; This needs to be improved.
 ; Transparent window that covers game screen to prevent game from capture the mouse.
 Gui, Controller: New
 Gui, Controller: +ToolWindow -Caption +AlwaysOnTop +HWNDstick
-Gui, Controller: Color, FFFFFF
+Gui, Controller: Color, 000000
 
 ; Spam user with useless info, first time script runs.
 IF (firstRun)


### PR DESCRIPTION
Changed transparent window color from white to black to fix bug in HDR mode where black levels are increased when the script is active.